### PR TITLE
Show site domain on bookmarks list

### DIFF
--- a/app/views/bookmarks/index.html.erb
+++ b/app/views/bookmarks/index.html.erb
@@ -21,6 +21,7 @@
         <a class="post-link" href="<%= bookmark.link %>">
           <%= bookmark.title&.truncate(50) %>
         </a>
+        <br><small class="text-muted"><%= URI.parse(bookmark.link).host rescue nil %></small>
       </td>
       <td style="max-width: 20em"><%= bookmark.content %></td>
       <td>


### PR DESCRIPTION
Displays the hostname of each bookmark's URL in small muted text below the title in the bookmarks index table, making it easier to identify the source site at a glance.