### PR TITLE
Include title and tags in Pagefind full-text search index

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -57,7 +57,7 @@ class Post < ApplicationModel
   end
 
   def tags
-    frontmatter["tags"] || []
+    Array(frontmatter["tags"])
   end
 
   def redirects

--- a/config/pagefind.rb
+++ b/config/pagefind.rb
@@ -31,7 +31,7 @@ class Pagefind
       for (const item of Object.values(searchData)) {
         const { errors } = await index.addCustomRecord({
           url: item.url,
-          content: item.title + "\n" + item.tags.join(" ") + "\n" + item.content,
+          content: item.title + "\n" + (Array.isArray(item.tags) ? item.tags : [item.tags]).join(" ") + "\n" + item.content,
           language: "en",
           meta: { title: item.title, published: item.published },
           filters: { tags: item.tags },
@@ -49,7 +49,7 @@ class Pagefind
     JS
 
     output, status = Open3.capture2e("node --input-type=module", stdin_data: script, chdir: Rails.root.to_s)
-    Rails.logger.debug output
+    Rails.logger.info output
     raise "Pagefind build failed" unless status.success?
 
     File.write(HASH_FILE, cache_key)

--- a/config/pagefind.rb
+++ b/config/pagefind.rb
@@ -31,7 +31,7 @@ class Pagefind
       for (const item of Object.values(searchData)) {
         const { errors } = await index.addCustomRecord({
           url: item.url,
-          content: item.content,
+          content: item.title + "\n" + item.tags.join(" ") + "\n" + item.content,
           language: "en",
           meta: { title: item.title, published: item.published },
           filters: { tags: item.tags },

--- a/config/pagefind.rb
+++ b/config/pagefind.rb
@@ -31,7 +31,7 @@ class Pagefind
       for (const item of Object.values(searchData)) {
         const { errors } = await index.addCustomRecord({
           url: item.url,
-          content: item.title + "\n" + (Array.isArray(item.tags) ? item.tags : [item.tags]).join(" ") + "\n" + item.content,
+          content: item.title + " " + item.tags.join(" ") + " " + item.content,
           language: "en",
           meta: { title: item.title, published: item.published },
           filters: { tags: item.tags },

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -11,4 +11,21 @@ RSpec.describe Post do
       expect(result.first.title).to eq("Pool Soup")
     end
   end
+
+  describe '#tags' do
+    it 'returns an empty array when tags is absent' do
+      post = described_class.new(frontmatter: {})
+      expect(post.tags).to eq([])
+    end
+
+    it 'returns an array when tags is already an array' do
+      post = described_class.new(frontmatter: { "tags" => ["ruby", "rails"] })
+      expect(post.tags).to eq(["ruby", "rails"])
+    end
+
+    it 'wraps a string tag in an array' do
+      post = described_class.new(frontmatter: { "tags" => "ruby" })
+      expect(post.tags).to eq(["ruby"])
+    end
+  end
 end


### PR DESCRIPTION
Post titles and tags were previously stored only as metadata/filters in the Pagefind index, making them unsearchable by keyword. This change prepends both the title and tags to the indexed `content` field so searching by post title or tag name returns matching results. Tags remain in `filters` for filter-based narrowing as well.