### PR TITLE
Fix bookmark workflow not triggering publish

### DIFF
--- a/.github/workflows/bookmark.yml
+++ b/.github/workflows/bookmark.yml
@@ -24,6 +24,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    outputs:
+      sha: ${{ steps.get_sha.outputs.sha }}
     steps:
       - name: Bookmark Details
         env:
@@ -56,8 +58,15 @@ jobs:
         run: |
           bundle exec scripts/bookmark.rb --commit="${GITHUB_REPOSITORY}#${GITHUB_REF##*/}"
 
-      - name: Trigger test and publish workflow
-        uses: peter-evans/repository-dispatch@v4
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          event-type: trigger-test-and-publish
+      - name: Get commit SHA
+        id: get_sha
+        run: echo "sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
+
+  test_and_publish:
+    name: Test and Publish
+    needs: create_bookmark
+    uses: ./.github/workflows/test_and_publish.yml
+    with:
+      ref: ${{ needs.create_bookmark.outputs.sha }}
+    permissions:
+      contents: write

--- a/.github/workflows/test_and_publish.yml
+++ b/.github/workflows/test_and_publish.yml
@@ -6,6 +6,12 @@ on:
     - cron: '0 7 * * *'
   repository_dispatch:
     types: [trigger-test-and-publish]
+  workflow_call:
+    inputs:
+      ref:
+        description: 'Git ref to checkout'
+        type: string
+        required: false
 concurrency:
   group: ${{ github.workflow}}-${{ github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
@@ -20,6 +26,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ref || '' }}
       - name: "Ruby: Install Ruby"
         uses: ruby/setup-ruby@v1
         with:


### PR DESCRIPTION
## Summary

- The `repository-dispatch` step in `bookmark.yml` was using `GITHUB_TOKEN`, which GitHub silently blocks from triggering new workflow runs (a platform restriction to prevent loops)
- Replaced it with `workflow_call`: `bookmark.yml` now calls `test_and_publish.yml` directly as a second job after the bookmark is committed
- The new commit SHA is captured and passed as a `ref` input so the publish step builds the correct revision including the new bookmark

## Test plan

- [ ] Trigger the "Create Bookmark" workflow dispatch and verify a second "Test and Publish" job runs and publishes to gh-pages