### PR TITLE
Bump minor dependency versions

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -224,7 +224,7 @@ GEM
       net-imap
       net-pop
       net-smtp
-    marcel (1.1.0)
+    marcel (1.1.1)
     matrix (0.4.3)
     mdl (0.15.0)
       kramdown (~> 2.3)
@@ -396,7 +396,7 @@ GEM
       lint_roller (~> 1.1)
       rubocop (>= 1.75.0, < 2.0)
       rubocop-ast (>= 1.47.1, < 2.0)
-    rubocop-rails (2.35.1)
+    rubocop-rails (2.35.2)
       activesupport (>= 4.2.0)
       lint_roller (~> 1.1)
       rack (>= 1.1)

--- a/app/models/bookmark.rb
+++ b/app/models/bookmark.rb
@@ -38,6 +38,12 @@ class Bookmark < ApplicationModel
     frontmatter.fetch("link", "")
   end
 
+  def link_host
+    URI.parse(link).host
+  rescue URI::InvalidURIError
+    nil
+  end
+
   def date
     if frontmatter["date"]
       Time.zone.parse(frontmatter["date"])

--- a/app/views/bookmarks/index.html.erb
+++ b/app/views/bookmarks/index.html.erb
@@ -21,7 +21,7 @@
         <a class="post-link" href="<%= bookmark.link %>">
           <%= bookmark.title&.truncate(50) %>
         </a>
-        <br><small class="text-muted"><%= URI.parse(bookmark.link).host rescue nil %></small>
+        <br><small class="text-muted"><%= bookmark.link_host %></small>
       </td>
       <td style="max-width: 20em"><%= bookmark.content %></td>
       <td>

--- a/package-lock.json
+++ b/package-lock.json
@@ -2359,9 +2359,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.357",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.357.tgz",
-      "integrity": "sha512-NHlTIQDK8fmVwHwuIzmXYEJ1Ewq3D9wDNc0cWXxDGysP6Pb21giwGNkxiTifyKy/4SoPuN5l6GLP1W9Sv7zB2g==",
+      "version": "1.5.359",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.359.tgz",
+      "integrity": "sha512-8lPELWuYZIWk7NDvCNthtmMw/7Q5Wu25NpM4djFMHBmk8DubPAtL4YTOp7ou0e7HyJtwkVlWv8XMLURnrtgJQw==",
       "dev": true,
       "license": "ISC"
     },
@@ -2902,9 +2902,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.14",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
-      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
       "dev": true,
       "funding": [
         {
@@ -2922,7 +2922,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },


### PR DESCRIPTION
Update lock files with minor dependency version bumps: marcel (1.1.0→1.1.1), rubocop-rails (2.35.1→2.35.2), electron-to-chromium (1.5.357→1.5.359), and postcss (8.5.14→8.5.15).