### PR TITLE
Fix typo

### DIFF
--- a/_posts/2026-05-14-one-year-of-ruby-on-rails-configuration.md
+++ b/_posts/2026-05-14-one-year-of-ruby-on-rails-configuration.md
@@ -401,7 +401,7 @@ Rails.application.configure do
 end
 ```
 
-Gzipped Sprocket include the build time and thus are uncacbable across builds. I'm waiting for [someone to look at my PR](https://github.com/rails/sprockets/pull/821).🤷
+Gzipped Sprocket include the build time and thus are uncacheable across builds. I'm waiting for [someone to look at my PR](https://github.com/rails/sprockets/pull/821).🤷
 
 ### Turbo Stream jobs
 


### PR DESCRIPTION
thanks for the article. 

I also feel that here: 
<img width="652" height="520" alt="image" src="https://github.com/user-attachments/assets/9d2f7b79-f292-4d7a-bca8-6118b85b6771" />


there is a missing script for `bin/productionrails` and / or explanation/description for `rbtrace`