### PR TITLE
Add Herb ERB linter to bin/lint

### DIFF
--- a/.herb.yml
+++ b/.herb.yml
@@ -1,0 +1,2 @@
+version: 0.10.1
+framework: actionview

--- a/Gemfile
+++ b/Gemfile
@@ -30,6 +30,7 @@ group :development, :test do
   gem "capybara"
   gem "cuprite"
   gem "erb_lint", require: false
+  gem "herb", require: false
   gem "mdl", require: false
   gem "rspec-rails"
   gem "rubocop-capybara", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -168,6 +168,8 @@ GEM
     google-protobuf (4.34.1-x86_64-linux-gnu)
       bigdecimal
       rake (~> 13.3)
+    herb (0.10.1-arm64-darwin)
+    herb (0.10.1-x86_64-linux-gnu)
     http-cookie (1.1.6)
       domain_name (~> 0.5)
     http_parser.rb (0.8.1)
@@ -493,6 +495,7 @@ DEPENDENCIES
   cuprite
   erb_lint
   front_matter_parser
+  herb
   jekyll
   kramdown-parser-gfm
   mdl

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -19,6 +19,6 @@
           <li><%= link_to related_post.title, post_path(related_post) %></li>
         <% end %>
       </ul>
+    </div>
   <% end %>
-  </div>
 </div>

--- a/bin/lint
+++ b/bin/lint
@@ -41,11 +41,18 @@ FileUtils.chdir APP_ROOT do
   puts '== Rubocop =='
   system! "bundle exec rubocop --no-server #{options[:nofix] ? '--parallel' : '--autocorrect'} --force-exclusion #{changed_files.join(' ')}"
 
-  puts "\n== ERB Lint =="
-  erblint_changed_files = changed_files.grep(/^app\/views\/.*\.erb$/)
+  erb_changed_files = changed_files.grep(/^app\/views\/.*\.erb$/)
 
-  if !options[:diff] || erblint_changed_files.any?
-    system! "bundle exec erb_lint #{options[:diff] ? erblint_changed_files.join(' ') : '.'}"
+  puts "\n== Herb =="
+  if !options[:diff] || erb_changed_files.any?
+    system! "bundle exec herb analyze app"
+  else
+    puts "No changes to ERB templates."
+  end
+
+  puts "\n== ERB Lint =="
+  if !options[:diff] || erb_changed_files.any?
+    system! "bundle exec erb_lint #{options[:diff] ? erb_changed_files.join(' ') : '.'}"
   else
     puts "No changes to ERB templates."
   end


### PR DESCRIPTION
Adds the `herb` gem and integrates it into `bin/lint` with a `== Herb ==` step that runs before ERB Lint, respecting the `--diff` flag for changed-files-only runs. A `.herb.yml` config sets `framework: actionview` for correct Rails ERB parsing. Running Herb also caught and fixed a misplaced `</div>` in `app/views/posts/show.html.erb` where the closing tag fell outside its `<% end %>` block.