### PR TITLE
Support published: false frontmatter for posts and bookmarks

### DIFF
--- a/app/controllers/bookmarks_controller.rb
+++ b/app/controllers/bookmarks_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 class BookmarksController < ApplicationController
   def index
-    @bookmarks = Bookmark.all.sort_by(&:date).reverse
+    @bookmarks = Bookmark.published.sort_by(&:date).reverse
   end
 
   def show

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -12,18 +12,18 @@ class PagesController < ApplicationController
   end
 
   def archives
-    @posts = Post.all.reverse
+    @posts = Post.published.reverse
   end
 
   def books
   end
 
   def tags
-    @posts = Post.all
+    @posts = Post.published
   end
 
   def feed
-    @posts = Post.all.reverse.take(10)
+    @posts = Post.published.reverse.take(10)
   end
 
   before_action :build_search_index, only: :search

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -7,7 +7,7 @@ class PostsController < ApplicationController
   def index
     @limit = LIMIT
     @page = params.fetch(:page, 1).to_i
-    @posts = Post.all.reverse.drop((@page - 1) * @limit).take(@limit)
+    @posts = Post.published.reverse.drop((@page - 1) * @limit).take(@limit)
   end
 
   def show
@@ -23,6 +23,6 @@ class PostsController < ApplicationController
     @tag = Post.tags.find { |tag| tag.parameterize == tag_slug }
     raise ActionController::RoutingError, "Not Found" unless @tag
 
-    @posts = Post.all.select { |post| post.tags.include?(@tag) }
+    @posts = Post.published.select { |post| post.tags.include?(@tag) }
   end
 end

--- a/app/controllers/robots_controller.rb
+++ b/app/controllers/robots_controller.rb
@@ -11,7 +11,7 @@ class RobotsController < ApplicationController
     @entries << SitemapEntry.new(loc: root_url)
     @entries << SitemapEntry.new(loc: about_url)
 
-    @entries += Post.all.map do |post|
+    @entries += Post.published.map do |post|
       SitemapEntry.new(loc: post_url(post))
     end
   end

--- a/app/models/bookmark.rb
+++ b/app/models/bookmark.rb
@@ -15,6 +15,10 @@ class Bookmark < ApplicationModel
     new(filepath: path, frontmatter: parsed.front_matter, body: parsed.content)
   end
 
+  def self.published
+    all.select(&:published?)
+  end
+
   def slug
     @_slug ||= begin
       _year, _month, _day, slug = filename.split("-", 4)
@@ -48,5 +52,9 @@ class Bookmark < ApplicationModel
 
   def content
     Kramdown::Document.new(body, input: 'GFM').to_html.html_safe # rubocop:disable Rails/OutputSafety
+  end
+
+  def published?
+    frontmatter["published"] != false
   end
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -20,7 +20,11 @@ class Post < ApplicationModel
   end
 
   def self.tags
-    all.flat_map(&:tags).uniq.sort
+    published.flat_map(&:tags).uniq.sort
+  end
+
+  def self.published
+    all.select(&:published?)
   end
 
   def self.from_file(path)
@@ -69,8 +73,7 @@ class Post < ApplicationModel
   def related_posts
     return [] if tags.empty?
 
-    self.class.all
-        .select(&:published?)
+    self.class.published
         .select { |post| post.tags.intersect?(tags) }
         .reject { |post| post == self }
         .sort_by(&:published_at)

--- a/app/views/pages/search.json.erb
+++ b/app/views/pages/search.json.erb
@@ -1,5 +1,5 @@
 <%
-  posts_hash = Post.all.sort_by(&:published_at).reverse.to_h do |post|
+  posts_hash = Post.published.sort_by(&:published_at).reverse.to_h do |post|
     [
       post_path(post).delete_prefix('/').parameterize,
       {

--- a/app/views/pages/tags.html.erb
+++ b/app/views/pages/tags.html.erb
@@ -1,7 +1,7 @@
 <% provide :title, "Tags" %>
 
 <%
-  all_tags = Post.all.flat_map(&:tags)
+  all_tags = Post.published.flat_map(&:tags)
   tag_counts = all_tags.tally
   sorted_tags = tag_counts.keys.sort_by(&:downcase)
 %>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -20,7 +20,7 @@
   <% if @page > 1 %>
     <a href="<%= posts_path(page: @page - 1) %>" class="btn btn-outline-primary">Newer posts</a>
   <% end %>
-  <% if @page < (Post.all.size.to_f / @limit).ceil %>
+  <% if @page < (Post.published.size.to_f / @limit).ceil %>
     <a href="<%= posts_path(page: @page + 1) %>" class="btn btn-outline-primary">Older posts</a>
   <% end %>
 </div>

--- a/config/pagefind.rb
+++ b/config/pagefind.rb
@@ -63,7 +63,7 @@ class Pagefind
 
   def search_json
     helpers = ActionController::Base.helpers
-    Post.all.sort_by(&:published_at).reverse.to_h do |post|
+    Post.published.sort_by(&:published_at).reverse.to_h do |post|
       url = "/#{post.published_at.strftime('%Y/%m')}/#{post.slug}"
       [
         url.delete_prefix('/').parameterize,

--- a/spec/models/bookmark_spec.rb
+++ b/spec/models/bookmark_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+require_relative "../rails_helper"
+
+RSpec.describe Bookmark do
+  describe '.load_all' do
+    it 'loads all bookmarks from _bookmarks directory' do
+      result = described_class.all
+
+      expect(result.size).to be > 1
+      expect(result.first).to be_a(described_class)
+    end
+  end
+
+  describe '#published?' do
+    it 'is true when the frontmatter has no published key' do
+      bookmark = described_class.new(frontmatter: {})
+      expect(bookmark.published?).to be(true)
+    end
+
+    it 'is true when published is explicitly true' do
+      bookmark = described_class.new(frontmatter: { "published" => true })
+      expect(bookmark.published?).to be(true)
+    end
+
+    it 'is false when published is explicitly false' do
+      bookmark = described_class.new(frontmatter: { "published" => false })
+      expect(bookmark.published?).to be(false)
+    end
+  end
+
+  describe '.published' do
+    it 'excludes unpublished bookmarks' do
+      published_bookmark = described_class.new(filepath: "#{Rails.root}/_bookmarks/2024/2024-01-01-published.md", frontmatter: { "published" => true })
+      unpublished_bookmark = described_class.new(filepath: "#{Rails.root}/_bookmarks/2024/2024-01-01-unpublished.md", frontmatter: { "published" => false })
+      allow(described_class).to receive(:all).and_return([published_bookmark, unpublished_bookmark])
+
+      expect(described_class.published).to eq([published_bookmark])
+    end
+  end
+end

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -11,4 +11,31 @@ RSpec.describe Post do
       expect(result.first.title).to eq("Pool Soup")
     end
   end
+
+  describe '#published?' do
+    it 'is true when the frontmatter has no published key' do
+      post = described_class.new(frontmatter: {})
+      expect(post.published?).to be(true)
+    end
+
+    it 'is true when published is explicitly true' do
+      post = described_class.new(frontmatter: { "published" => true })
+      expect(post.published?).to be(true)
+    end
+
+    it 'is false when published is explicitly false' do
+      post = described_class.new(frontmatter: { "published" => false })
+      expect(post.published?).to be(false)
+    end
+  end
+
+  describe '.published' do
+    it 'excludes unpublished posts' do
+      published_post = described_class.new(filepath: "#{Rails.root}/_posts/2024-01-01-published.md", frontmatter: { "published" => true })
+      unpublished_post = described_class.new(filepath: "#{Rails.root}/_posts/2024-01-01-unpublished.md", frontmatter: { "published" => false })
+      allow(described_class).to receive(:all).and_return([published_post, unpublished_post])
+
+      expect(described_class.published).to eq([published_post])
+    end
+  end
 end

--- a/spec/requests/feed_spec.rb
+++ b/spec/requests/feed_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.describe "Feed" do
+  describe "GET /feed" do
+    let(:published_post) do
+      Post.new(
+        filepath: "#{Rails.root}/_posts/2024-03-21-published-post.md",
+        frontmatter: { "title" => "Published Post", "date" => "2024-03-21", "published" => true },
+        body: "Published content"
+      )
+    end
+
+    let(:unpublished_post) do
+      Post.new(
+        filepath: "#{Rails.root}/_posts/2024-03-20-unpublished-post.md",
+        frontmatter: { "title" => "Unpublished Post", "date" => "2024-03-20", "published" => false },
+        body: "Unpublished content"
+      )
+    end
+
+    before do
+      allow(Post).to receive(:all).and_return([published_post, unpublished_post])
+    end
+
+    it "includes published posts" do
+      get feed_path(format: :xml)
+
+      expect(response.body).to include("Published Post")
+    end
+
+    it "excludes unpublished posts" do
+      get feed_path(format: :xml)
+
+      expect(response.body).not_to include("Unpublished Post")
+    end
+  end
+end


### PR DESCRIPTION
Adds a `published` frontmatter flag (defaulting to true) so posts and bookmarks with `published: false` are hidden from public listings. Introduces `Post.published` and `Bookmark.published` scopes plus `Bookmark#published?`, and switches the post index/archives/tags/feed, bookmark index, sitemap, pagination count, and Pagefind search index from `.all` to `.published`. Individual show pages still resolve via `.all`, so unpublished items remain reachable by direct URL. Includes new model specs for `published?`/`.published` and a request spec verifying the feed excludes unpublished posts.