### PR TITLE
Add xruby fenced code blocks with irb-style # => annotations

### DIFF
--- a/.idea/island94.iml
+++ b/.idea/island94.iml
@@ -82,6 +82,7 @@
     <orderEntry type="library" scope="PROVIDED" name="front_matter_parser (v1.0.1, mise: 4.0.4) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="globalid (v1.4.0, mise: 4.0.4) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="google-protobuf (v4.35.1, mise: 4.0.4) [gem]" level="application" />
+    <orderEntry type="library" scope="TEST" name="herb (v0.10.1, mise: 4.0.4) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="http-cookie (v1.1.6, mise: 4.0.4) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="http_parser.rb (v0.8.1, mise: 4.0.4) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="i18n (v1.15.2, mise: 4.0.4) [gem]" level="application" />

--- a/app/lib/xruby_filter.rb
+++ b/app/lib/xruby_filter.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+require "ripper"
+
+# Executes ```xruby fenced code blocks as Ruby, rewriting the fence to
+# ```ruby (so it still gets normal Rouge syntax highlighting) and filling in
+# any trailing `# =>` / `#=>` comment with the evaluated value of that line,
+# REPL-annotation style (like irb/pry/seeing_is_believing).
+#
+# All xruby blocks within a single #call share one execution context: a
+# single Binding, opened fresh per document against an anonymous Module.
+# Local variables, instance variables, and constants/classes defined in one
+# block are all visible to later blocks in the same document (since every
+# block reuses that one Binding — the same trick a REPL uses to keep state
+# between lines), but are invisible to any other document's context — and,
+# crucially, can never collide with or monkeypatch a real application
+# constant (e.g. `class Post`), since they live in their own private
+# namespace rather than on Object.
+#
+# The cost of that isolation is cosmetic: a class defined inside the
+# anonymous module reports its name as e.g. "#<Module:0x00...>::Greeter"
+# rather than plain "Greeter". ANONYMOUS_MODULE_PREFIX strips that prefix
+# back out of any inspected `# =>` value, so the annotation reads cleanly.
+#
+# Lines are buffered until they parse as a complete Ruby statement (the same
+# "keep reading or execute now?" check irb/pry use), so multi-line
+# constructs (class/def/do...end) evaluate as a single statement. Only the
+# final line of a completed statement can carry a `# =>` annotation; a
+# marker on an earlier line of a multi-line statement is left untouched.
+class XrubyFilter
+  FENCE = /^```xruby\n(.*?)^```\n/m
+  ANNOTATION = /\A(.*?)(#\s*=>).*\z/
+  ANONYMOUS_MODULE_PREFIX = /#<(?:Module|Class):0x\h+>::/
+
+  def self.call(markdown)
+    new.call(markdown)
+  end
+
+  def call(markdown)
+    block_binding = Module.new.module_eval("binding", __FILE__, __LINE__)
+
+    markdown.gsub(FENCE) do
+      "```ruby\n#{evaluate_block(Regexp.last_match(1), block_binding)}```\n"
+    end
+  end
+
+  private
+
+  def evaluate_block(code, block_binding)
+    output = +""
+    buffer = +""
+    buffer_start_line = nil
+
+    code.each_line.with_index(1) do |line, line_number|
+      buffer_start_line ||= line_number
+      buffer << line
+
+      next unless complete_statement?(buffer)
+
+      value = block_binding.eval(buffer, "(xruby)", buffer_start_line)
+      output << annotate(buffer, value)
+
+      buffer = +""
+      buffer_start_line = nil
+    end
+
+    # An unterminated buffer (e.g. a missing `end`) means the block never
+    # parsed as complete Ruby — eval it anyway so the real SyntaxError
+    # surfaces, rather than silently dropping the trailing lines.
+    block_binding.eval(buffer, "(xruby)", buffer_start_line) unless buffer.empty?
+
+    output
+  end
+
+  def complete_statement?(code)
+    !Ripper.sexp(code).nil?
+  end
+
+  def annotate(buffer, value)
+    lines = buffer.lines
+    last_line = lines.pop
+    newline = last_line.end_with?("\n") ? "\n" : ""
+    match = last_line.chomp.match(ANNOTATION)
+    return buffer unless match
+
+    code = match[1]
+    marker = match[2]
+    formatted_value = value.inspect.gsub(ANONYMOUS_MODULE_PREFIX, "")
+    "#{lines.join}#{code.rstrip} #{marker} #{formatted_value}#{newline}"
+  end
+end

--- a/app/models/bookmark.rb
+++ b/app/models/bookmark.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 class Bookmark < ApplicationModel
+  include Markdownable
+
   attribute :filepath, :string
   attribute :frontmatter, default: -> { {} }
   attribute :body, :string
@@ -47,6 +49,6 @@ class Bookmark < ApplicationModel
   end
 
   def content
-    Kramdown::Document.new(body, input: 'GFM').to_html.html_safe # rubocop:disable Rails/OutputSafety
+    render_markdown(body)
   end
 end

--- a/app/models/concerns/markdownable.rb
+++ b/app/models/concerns/markdownable.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+module Markdownable
+  extend ActiveSupport::Concern
+
+  def render_markdown(text)
+    Kramdown::Document.new(XrubyFilter.call(text), input: 'GFM').to_html.html_safe # rubocop:disable Rails/OutputSafety
+  end
+end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 class Post < ApplicationModel
+  include Markdownable
+
   attribute :filepath, :string
   attribute :frontmatter, default: -> { {} }
   attribute :body, :string
@@ -45,7 +47,7 @@ class Post < ApplicationModel
   end
 
   def content
-    @_content ||= Kramdown::Document.new(body, input: 'GFM').to_html.html_safe # rubocop:disable Rails/OutputSafety
+    @_content ||= render_markdown(body)
   end
 
   def published_at

--- a/spec/lib/xruby_filter_spec.rb
+++ b/spec/lib/xruby_filter_spec.rb
@@ -1,0 +1,251 @@
+# frozen_string_literal: true
+require_relative "../rails_helper"
+
+RSpec.describe XrubyFilter do
+  describe ".call" do
+    it "rewrites an xruby fence to a ruby fence" do
+      markdown = <<~MARKDOWN
+        ```xruby
+        1 + 1
+        ```
+      MARKDOWN
+
+      expect(described_class.call(markdown)).to eq(<<~MARKDOWN)
+        ```ruby
+        1 + 1
+        ```
+      MARKDOWN
+    end
+
+    it "fills in a trailing `# =>` comment with the evaluated value" do
+      markdown = <<~MARKDOWN
+        ```xruby
+        1 + 1 # =>
+        ```
+      MARKDOWN
+
+      expect(described_class.call(markdown)).to include("1 + 1 # => 2")
+    end
+
+    it "fills in a trailing `#=>` comment with the evaluated value" do
+      markdown = <<~MARKDOWN
+        ```xruby
+        1 + 1 #=>
+        ```
+      MARKDOWN
+
+      expect(described_class.call(markdown)).to include("1 + 1 #=> 2")
+    end
+
+    it "renders the value with #inspect, quoting strings" do
+      markdown = <<~MARKDOWN
+        ```xruby
+        "hello" # =>
+        ```
+      MARKDOWN
+
+      expect(described_class.call(markdown)).to include('"hello" # => "hello"')
+    end
+
+    it "replaces a stale value already present after the marker" do
+      markdown = <<~MARKDOWN
+        ```xruby
+        1 + 1 # => 999
+        ```
+      MARKDOWN
+
+      expect(described_class.call(markdown)).to include("1 + 1 # => 2")
+      expect(described_class.call(markdown)).not_to include("999")
+    end
+
+    it "leaves lines without a marker untouched, though still executed" do
+      markdown = "```xruby\nx = 1 + 2\nx # =>\n```\n"
+
+      result = described_class.call(markdown)
+      expect(result).to include("x = 1 + 2\n")
+      expect(result).to include("x # => 3")
+    end
+
+    it "persists instance variables across separate xruby blocks in one document" do
+      markdown = <<~MARKDOWN
+        ```xruby
+        @count = 1
+        ```
+
+        ```xruby
+        @count += 1
+        @count # =>
+        ```
+      MARKDOWN
+
+      expect(described_class.call(markdown)).to include("@count # => 2")
+    end
+
+    it "persists local variables across separate xruby blocks in one document" do
+      markdown = <<~MARKDOWN
+        ```xruby
+        x = 1
+        ```
+
+        ```xruby
+        x += 1
+        x # =>
+        ```
+      MARKDOWN
+
+      expect(described_class.call(markdown)).to include("x # => 2")
+    end
+
+    it "does not persist local variables between separate .call invocations" do
+      markdown = <<~MARKDOWN
+        ```xruby
+        x = 1
+        ```
+      MARKDOWN
+      described_class.call(markdown)
+
+      other_markdown = <<~MARKDOWN
+        ```xruby
+        x # =>
+        ```
+      MARKDOWN
+
+      expect { described_class.call(other_markdown) }.to raise_error(NameError)
+    end
+
+    it "evaluates a multi-line statement as one chunk, and later blocks can use it" do
+      markdown = <<~MARKDOWN
+        ```xruby
+        class Greeter
+          def hello = "hello"
+        end
+        ```
+
+        ```xruby
+        Greeter.new.hello # =>
+        ```
+      MARKDOWN
+
+      result = described_class.call(markdown)
+      expect(result).to include(<<~RUBY)
+        class Greeter
+          def hello = "hello"
+        end
+      RUBY
+      expect(result).to include('Greeter.new.hello # => "hello"')
+    end
+
+    it "isolates constants between separate .call invocations" do
+      markdown = <<~MARKDOWN
+        ```xruby
+        class Thing
+          VALUE = 1
+        end
+        Thing::VALUE # =>
+        ```
+      MARKDOWN
+
+      expect(described_class.call(markdown)).to include("Thing::VALUE # => 1")
+      expect(described_class.call(markdown)).to include("Thing::VALUE # => 1")
+    end
+
+    it "gives classes defined in a block a clean, unprefixed name" do
+      markdown = <<~MARKDOWN
+        ```xruby
+        class Greeter
+        end
+        Greeter.name # =>
+        Greeter # =>
+        ```
+      MARKDOWN
+
+      result = described_class.call(markdown)
+      expect(result).to include('Greeter.name # => "Greeter"')
+      expect(result).to include("Greeter # => Greeter")
+    end
+
+    it "does not affect a real top-level class of the same name" do
+      markdown = <<~MARKDOWN
+        ```xruby
+        class String
+          def shout = upcase + "!"
+        end
+        ```
+      MARKDOWN
+
+      described_class.call(markdown)
+
+      expect(String.method_defined?(:shout)).to be(false)
+    end
+
+    it "does not affect a real application model of the same name" do
+      markdown = <<~MARKDOWN
+        ```xruby
+        class Post
+          def evil = "gotcha"
+        end
+        ```
+      MARKDOWN
+
+      described_class.call(markdown)
+
+      expect(Post.method_defined?(:evil)).to be(false)
+    end
+
+    it "allows reopening a class defined earlier in the same document" do
+      markdown = <<~MARKDOWN
+        ```xruby
+        class Greeter
+          def hello = "hello"
+        end
+        ```
+
+        ```xruby
+        class Greeter
+          def bye = "bye"
+        end
+        Greeter.new.bye # =>
+        ```
+      MARKDOWN
+
+      expect(described_class.call(markdown)).to include('Greeter.new.bye # => "bye"')
+    end
+
+    it "does not leak classes into the global namespace after processing" do
+      markdown = <<~MARKDOWN
+        ```xruby
+        class Greeter
+        end
+        ```
+      MARKDOWN
+
+      described_class.call(markdown)
+
+      expect(Object.const_defined?(:Greeter)).to be(false)
+    end
+
+    it "raises a SyntaxError for genuinely broken Ruby" do
+      markdown = <<~MARKDOWN
+        ```xruby
+        class Broken
+        ```
+      MARKDOWN
+
+      expect { described_class.call(markdown) }.to raise_error(SyntaxError)
+    end
+
+    it "leaves non-xruby fences untouched" do
+      markdown = <<~MARKDOWN
+        ```ruby
+        1 + 1 # =>
+        ```
+
+        ```javascript
+        1 + 1 // =>
+        ```
+      MARKDOWN
+
+      expect(described_class.call(markdown)).to eq(markdown)
+    end
+  end
+end

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -11,4 +11,42 @@ RSpec.describe Post do
       expect(result.first.title).to eq("Pool Soup")
     end
   end
+
+  describe '#content' do
+    it 'executes xruby code blocks and annotates `# =>` comments with their values' do
+      body = <<~MARKDOWN
+        ```xruby
+        x = 1 + 2
+        @y = x # =>
+        ```
+
+        ```xruby
+        @y += 1
+        @y #=>
+        ```
+
+        ```xruby
+        class Greeter
+          def hello = "hello"
+        end
+        ```
+
+        ```xruby
+        Greeter.new.hello # =>
+        Greeter.new.class.name # =>
+        Greeter # =>
+        Greeter.name # =>
+        ```
+      MARKDOWN
+
+      with_temporary_post(filename: "2026-01-01-xruby-test-post.md", body: body) do |post|
+        expect(post.content).to include('class="language-ruby highlighter-rouge"')
+        expect(post.content).to include("# =&gt; 3")
+        expect(post.content).to include("#=&gt; 4")
+        expect(post.content).to include('# =&gt; "hello"')
+        expect(post.content).to include("# =&gt; Greeter")
+        expect(post.content).to include('# =&gt; "Greeter"')
+      end
+    end
+  end
 end

--- a/spec/support/temporary_post.rb
+++ b/spec/support/temporary_post.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+# Writes a real file into _posts/ (Post.all has no injectable path, so this
+# is the only way to exercise it end-to-end), yields the loaded Post, then
+# always deletes the file and busts Post's memoized .all cache — so specs
+# never need to commit a permanent "test" post to the real blog.
+module TemporaryPost
+  def with_temporary_post(filename:, body:, **frontmatter)
+    frontmatter = { title: "Temporary Test Post", published: true, tags: [] }.merge(frontmatter)
+    front_matter_yaml = frontmatter.map { |key, value| "#{key}: #{value.to_json}" }.join("\n")
+    path = Rails.root.join("_posts", filename)
+
+    File.write(path, "---\n#{front_matter_yaml}\n---\n\n#{body}")
+    Post.reset
+
+    post = Post.all.find { |p| p.filepath == path.to_s }
+    raise "temporary post not found after writing #{path}" unless post
+
+    yield post
+  ensure
+    FileUtils.rm_f(path)
+    Post.reset
+  end
+end
+
+RSpec.configure do |config|
+  config.include TemporaryPost
+end

--- a/spec/system/posts_spec.rb
+++ b/spec/system/posts_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.describe "Posts" do
+  it "renders executed xruby code blocks with their `# =>` values" do
+    body = <<~MARKDOWN
+      ```xruby
+      x = 1 + 2
+      @y = x # =>
+      ```
+
+      ```xruby
+      @y += 1
+      @y #=>
+      ```
+
+      ```xruby
+      class Greeter
+        def hello = "hello"
+      end
+      ```
+
+      ```xruby
+      Greeter.new.hello # =>
+      Greeter.new.class.name # =>
+      Greeter # =>
+      Greeter.name # =>
+      ```
+    MARKDOWN
+
+    with_temporary_post(filename: "2026-01-01-xruby-system-test-post.md", body: body) do |post|
+      visit "/#{post.published_at.strftime('%Y/%m')}/#{post.slug}"
+
+      expect(page).to have_title(post.title)
+      within ".post-content" do
+        expect(page).to have_css(".language-ruby")
+        expect(page).to have_text("# => 3")
+        expect(page).to have_text("#=> 4")
+        expect(page).to have_text('# => "hello"')
+        expect(page).to have_text("# => Greeter")
+        expect(page).to have_text('# => "Greeter"')
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Adds `XrubyFilter`, which executes ```xruby fenced code blocks (sharing one Binding per document) before Kramdown rendering, rewrites the fence to ```ruby for highlighting, and fills in trailing `# =>` / `#=>` comments with the evaluated value, REPL-annotation style.
- Extracts a `Markdownable` concern shared by `Post` and `Bookmark`, replacing their duplicated `Kramdown::Document.new(body, input: 'GFM').to_html` calls with `render_markdown`, now routed through `XrubyFilter`.
- Adds a `spec/support/temporary_post.rb` helper that writes a real file into `_posts/` for end-to-end specs, plus model and system specs covering the xruby annotation behavior.

## Test plan
- [x] `bundle exec rspec spec/lib/xruby_filter_spec.rb spec/models/post_spec.rb`