### PR TITLE
Fix Rouge::Formatters::HTMLLegacy deprecation warning

### DIFF
--- a/app/assets/stylesheets/vendor/rouge/_magritte_light.scss
+++ b/app/assets/stylesheets/vendor/rouge/_magritte_light.scss
@@ -49,6 +49,10 @@
   .highlight .ge {
     font-style: italic;
   }
+  .highlight .ges {
+    font-weight: bold;
+    font-style: italic;
+  }
   .highlight .gs {
     font-weight: bold;
   }

--- a/app/assets/stylesheets/vendor/rouge/_molokai_dark.scss
+++ b/app/assets/stylesheets/vendor/rouge/_molokai_dark.scss
@@ -35,7 +35,10 @@
     color: #f92672;
   }
   .highlight .ge {
-    color: #1b1d1e;
+    font-style: italic;
+  }
+  .highlight .ges {
+    font-weight: bold;
     font-style: italic;
   }
   .highlight .gr {

--- a/app/helpers/markdown_helper.rb
+++ b/app/helpers/markdown_helper.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 module MarkdownHelper
   def markdownify(text)
-    Kramdown::Document.new(text, input: 'GFM').to_html.html_safe # rubocop:disable Rails/OutputSafety
+    Kramdown::Document.new(text, input: 'GFM', syntax_highlighter_opts: { formatter: RougeHtmlFormatter }).to_html.html_safe # rubocop:disable Rails/OutputSafety
   end
 end

--- a/app/lib/rouge_html_formatter.rb
+++ b/app/lib/rouge_html_formatter.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+# Kramdown defaults to the deprecated Rouge::Formatters::HTMLLegacy, which
+# wraps rendered token spans in <div class="highlight"><pre class="highlight">
+# <code>...markup that app/assets/stylesheets/application.css.scss and the
+# rouge theme partials style via ".highlighter-rouge > .highlight". This is
+# that same wrapping without the deprecation warning.
+class RougeHtmlFormatter < Rouge::Formatters::HTML
+  def stream(tokens, &)
+    yield %(<div class="highlight"><pre class="highlight"><code>)
+    super
+    yield "</code></pre></div>"
+  end
+end

--- a/app/models/concerns/markdownable.rb
+++ b/app/models/concerns/markdownable.rb
@@ -3,6 +3,6 @@ module Markdownable
   extend ActiveSupport::Concern
 
   def render_markdown(text)
-    Kramdown::Document.new(XrubyFilter.call(text), input: 'GFM').to_html.html_safe # rubocop:disable Rails/OutputSafety
+    Kramdown::Document.new(XrubyFilter.call(text), input: 'GFM', syntax_highlighter_opts: { formatter: RougeHtmlFormatter }).to_html.html_safe # rubocop:disable Rails/OutputSafety
   end
 end


### PR DESCRIPTION
- Kramdown's Rouge integration falls back to the deprecated `Rouge::Formatters::HTMLLegacy` whenever no `formatter` option is set.
- Adds `RougeHtmlFormatter`, a small `Rouge::Formatters::HTML` subclass that reproduces the exact same `<div class="highlight"><pre class="highlight"><code>` wrapping (which the CSS's `.highlighter-rouge > .highlight` selector relies on), without the deprecation warning.
- Wires it in via `syntax_highlighter_opts: { formatter: RougeHtmlFormatter }` in `Markdownable#render_markdown` and `MarkdownHelper#markdownify`.
- Regenerates the checked-in `magritte`/`molokai` theme CSS (`bundle exec rougify style ...`) since we're already on the latest rouge (5.0.0) but the committed CSS predated a couple of upstream theme tweaks: adds the `.ges` (bold+italic generic emphasis) rule, and drops a stray near-black `color` on molokai's `.ge` that made that text unreadable on the dark background.